### PR TITLE
Check selector scope before running autocomplete

### DIFF
--- a/CoffeeAutocomplete.py
+++ b/CoffeeAutocomplete.py
@@ -31,6 +31,8 @@ class CoffeeAutocomplete(sublime_plugin.EventListener):
 
 		# If there is a word selection and we're looking at a coffee file...
 		if not completions and coffee_utils.is_coffee_syntax(view) and not working:
+			if not view.match_selector(locations[0], "source.coffee -comment"):
+				return []
 
 			status["working"] = True
 


### PR DESCRIPTION
I needed this specifically for compatibility with [DocBlockr](https://github.com/spadgos/sublime-jsdocs), whose autocompletes for jsdoc comment tags were getting overwritten by CC+.  

(Also fixes justinmahar#27.)
