### PR TITLE
Fix Sublime Text 3 support

### DIFF
--- a/CoffeeGotoDefinition.py
+++ b/CoffeeGotoDefinition.py
@@ -2,8 +2,15 @@ import sublime, sublime_plugin
 import re
 import os
 import threading
-import coffee_utils
-from coffee_utils import debug
+
+try:
+	# Python 3
+	from . import coffee_utils
+	from .coffee_utils import debug
+except (ValueError):
+	# Python 2
+	import coffee_utils
+	from coffee_utils import debug
 
 COMMAND_NAME = 'coffee_goto_definition'
 STATUS_MESSAGE_DEFINITION_FOUND = "Coffee: Definition for \"%s\" found."


### PR DESCRIPTION
The "goto definition" was forgotten while adding support for Sublime Text 3.

(Also fixes error reported by @edubkendo in #39)
